### PR TITLE
Update for latest version of Rack

### DIFF
--- a/lib/omnicontacts/builder.rb
+++ b/lib/omnicontacts/builder.rb
@@ -23,7 +23,7 @@ module OmniContacts
     end
 
     def call env
-      @ins << @app unless @ins.include?(@app)
+      @ins << @app unless rack14? || @ins.include?(@app)
       to_app.call(env)
     end
   end


### PR DESCRIPTION
The latest version of rack fails on the @env variable.  This change duplicates the functionality in omniauth
