### PR TITLE
Update lib/omnicontacts/http_utils.rb

### DIFF
--- a/lib/omnicontacts/http_utils.rb
+++ b/lib/omnicontacts/http_utils.rb
@@ -36,7 +36,19 @@ module OmniContacts
     def host_url_from_rack_env env
       port = ( (env["SERVER_PORT"] == 80) && "") || ":#{env['SERVER_PORT']}"  
       host = (env["HTTP_HOST"]) || (env["SERVER_NAME"] + port)
-      env["rack.url_scheme"] + "://" + host
+      scheme(env) + "://" + host
+    end
+    
+    def scheme env
+      if env['HTTPS'] == 'on'
+        'https'
+      elsif env['HTTP_X_FORWARDED_SSL'] == 'on'
+        'https'
+      elsif env['HTTP_X_FORWARDED_PROTO']
+        env['HTTP_X_FORWARDED_PROTO'].split(',')[0]
+      else
+        env["rack.url_scheme"]
+      end
     end
 
     # Classes including the module must respond to the ssl_ca_file message in order to use the following methods.


### PR DESCRIPTION
Sometimes HTTP headers other than env["rack.url_scheme"] are used to specify an HTTPS scheme (for example when nginx is used)

I added checks for the other headers similar to rack's code: https://github.com/rack/rack/blob/master/lib/rack/request.rb#L70
