### PR TITLE
support for gmail contacts without gd:fullName element

### DIFF
--- a/lib/omnicontacts/importer/gmail.rb
+++ b/lib/omnicontacts/importer/gmail.rb
@@ -41,7 +41,8 @@ module OmniContacts
             contact = {:email => gd_email.attributes['address']}
             gd_name = entry.elements['gd:name']
             if gd_name
-              contact[:name] = gd_name.elements['gd:fullName'].text
+              gd_full_name = gd_name.elements['gd:fullName']
+              contact[:name] = gd_full_name.text if gd_full_name
             end
             contacts << contact
           end

--- a/spec/omnicontacts/importer/gmail_spec.rb
+++ b/spec/omnicontacts/importer/gmail_spec.rb
@@ -14,6 +14,13 @@ describe OmniContacts::Importer::Gmail do
      </entry>"
   }
 
+  let(:contact_without_fullname) {
+    "<entry xmlns:gd='http://schemas.google.com/g/2005'>
+       <gd:name/>
+       <gd:email rel='http://schemas.google.com/g/2005#work' primary='true' address='bennet@gmail.com'/>
+     </entry>"
+  }
+
   describe "fetch_contacts_using_access_token" do
 
     let(:token) { "token" }
@@ -33,6 +40,14 @@ describe OmniContacts::Importer::Gmail do
       result = gmail.fetch_contacts_using_access_token token, token_type
       result.size.should be(1)
       result.first[:name].should eq("Edward Bennet")
+      result.first[:email].should eq("bennet@gmail.com")
+    end
+
+    it "should handle contact without fullname" do
+      gmail.should_receive(:https_get).and_return(contact_without_fullname)
+      result = gmail.fetch_contacts_using_access_token token, token_type
+      result.size.should be(1)
+      result.first[:name].should be_nil
       result.first[:email].should eq("bennet@gmail.com")
     end
 


### PR DESCRIPTION
Hi-

When trying this out I noticed that there were some contacts that gmail returned without a gd:fullName element, which broke the importer. Here's a pull request for that as well as a test.
