### PR TITLE
Include avatars for returned contacts

### DIFF
--- a/lib/omnicontacts/importer/gmail.rb
+++ b/lib/omnicontacts/importer/gmail.rb
@@ -20,7 +20,7 @@ module OmniContacts
 
       def fetch_contacts_using_access_token access_token, token_type
         contacts_response = https_get(@contacts_host, @contacts_path, contacts_req_params, contacts_req_headers(access_token, token_type))
-        parse_contacts contacts_response
+        parse_contacts contacts_response, access_token, token_type
       end
 
       private
@@ -33,9 +33,11 @@ module OmniContacts
         {"GData-Version" => "3.0", "Authorization" => "#{token_type} #{token}"}
       end
 
-      def parse_contacts contacts_as_xml
+      def parse_contacts contacts_as_xml, access_token, token_type
         xml = REXML::Document.new(contacts_as_xml)
         contacts = []
+        contacts << {:access_token => access_token}
+
         xml.elements.each('//entry') do |entry|
           gd_email = entry.elements['gd:email']
           if gd_email
@@ -45,6 +47,19 @@ module OmniContacts
               gd_full_name = gd_name.elements['gd:fullName']
               contact[:name] = gd_full_name.text if gd_full_name
             end
+
+            gd_avatar = entry.elements['link[@type="image/*"]']
+            contact[:avatar_url] = gd_avatar ? gd_avatar.attribute('href').to_s : nil
+            
+            ### Use the below if you want to return the avatar file itself.
+            # if gd_avatar
+            #   avatar_url_parsed = URI.parse(gd_avatar.attribute('href').to_s)
+            #   avatar_host = avatar_url_parsed.host
+            #   avatar_path = avatar_url_parsed.path
+            #   avatar_response = https_get(avatar_host, avatar_path, contacts_req_params, contacts_req_headers(access_token, token_type))
+              # contact[:avatar] = avatar_response.body if avatar_response.status_code == 200
+            # end
+            
             contacts << contact
           end
         end


### PR DESCRIPTION
I wrote two ways to retrieve avatars: the avatar URL as supplied by Google Contacts API, or the avatar itself. 

In my case I opted to use the avatar url (which requires authentication), and so I send the access token along with the list of contacts.

Feel free to improve as you see fit. Cheers!
