### PR TITLE
Change scope for readonly

### DIFF
--- a/lib/omnicontacts/importer/gmail.rb
+++ b/lib/omnicontacts/importer/gmail.rb
@@ -12,7 +12,7 @@ module OmniContacts
         @auth_host = "accounts.google.com"
         @authorize_path = "/o/oauth2/auth"
         @auth_token_path = "/o/oauth2/token"
-        @scope = "https://www.google.com/m8/feeds"
+        @scope = "https://www.googleapis.com/auth/contacts.readonly"
         @contacts_host = "www.google.com"
         @contacts_path = "/m8/feeds/contacts/default/full"
         @max_results =  (args[3] && args[3][:max_results]) || 100


### PR DESCRIPTION
Shows 'View' vs. 'Manage' contacts in the Google OAuth page.

This is stricter and probably increases the chance of users accepting.
