### PR TITLE
Fix for issue #39 - Default value for HTTP headers should a Hash and not Array

### DIFF
--- a/lib/omnicontacts/http_utils.rb
+++ b/lib/omnicontacts/http_utils.rb
@@ -74,7 +74,7 @@ module OmniContacts
 
     # Executes an HTTP GET request over SSL
     # It raises a RuntimeError if the response code is not equal to 200
-    def https_get host, path, params, headers =[]
+    def https_get host, path, params, headers ={}
       https_connection host do |connection|
         connection.request_get(path + "?" + to_query_string(params), headers)
       end


### PR DESCRIPTION
Ruby HTTP library requires the headers to be provided as a Hash. The default value was an empty Array resulting in a NoMethodError when the default value was used.

Fix for issue #39
