### PR TITLE
Facebook import and extended contact parameters

### DIFF
--- a/lib/omnicontacts/authorization/oauth2.rb
+++ b/lib/omnicontacts/authorization/oauth2.rb
@@ -56,6 +56,9 @@ module OmniContacts
       end
 
       def access_token_from_response response
+        if auth_host == "graph.facebook.com"
+          response = query_string_to_map(response).to_json
+        end
         json = JSON.parse(response)
         raise json["error"] if json["error"]
         [json["access_token"], json["token_type"], json["refresh_token"]]

--- a/lib/omnicontacts/http_utils.rb
+++ b/lib/omnicontacts/http_utils.rb
@@ -10,6 +10,43 @@ module OmniContacts
 
     module_function
 
+    # return has of birthday day, month and year
+    def birthday_format month, day, year
+      return {:day => day.to_i, :month => month.to_i, :year => year.to_i}if year && month && day
+      return {:day => day.to_i, :month => month.to_i, :year => nil} if !year && month && day
+      return nil if (!year && !month) || (!year && !day)
+    end
+
+    # normalize the name
+    def normalize_name name
+      return nil if name.nil?
+      name.chomp!
+      name = name.split(' ').map(&:capitalize).join(' ')
+      name.squeeze!(' ')
+      name.strip!
+      return name
+    end
+
+    # create a full name given the individual first and last name
+    def full_name first_name, last_name
+      return "#{first_name} #{last_name}" if first_name && last_name
+      return "#{first_name}" if first_name && !last_name
+      return "#{last_name}" if !first_name && last_name
+      return nil
+    end
+
+    # create a username/name from a given email
+    def email_to_name username_or_email
+      username_or_email = username_or_email.split('@').first if username_or_email.include?('@')
+      if group = (/(?<first>[a-z|A-Z]+)[\.|_](?<last>[a-z|A-Z]+)/).match(username_or_email)
+        first_name = normalize_name(group[:first])
+        last_name = normalize_name(group[:last])
+        return first_name, last_name, "#{first_name} #{last_name}"
+      end
+      username = normalize_name(username_or_email)
+      return username, nil, username
+    end
+
     def query_string_to_map query_string
       query_string.split('&').reduce({}) do |memo, key_value|
         (key, value) = key_value.split('=')
@@ -73,7 +110,7 @@ module OmniContacts
 
     # Executes an HTTP GET request over SSL
     # It raises a RuntimeError if the response code is not equal to 200
-    def https_get host, path, params, headers =[]
+    def https_get host, path, params, headers = nil
       https_connection host do |connection|
         connection.request_get(path + "?" + to_query_string(params), headers)
       end

--- a/lib/omnicontacts/importer.rb
+++ b/lib/omnicontacts/importer.rb
@@ -4,6 +4,7 @@ module OmniContacts
     autoload :Gmail, "omnicontacts/importer/gmail"
     autoload :Yahoo, "omnicontacts/importer/yahoo"
     autoload :Hotmail, "omnicontacts/importer/hotmail"
+    autoload :Facebook, "omnicontacts/importer/facebook"
 
   end
 end

--- a/lib/omnicontacts/importer/facebook.rb
+++ b/lib/omnicontacts/importer/facebook.rb
@@ -1,0 +1,93 @@
+require "omnicontacts/middleware/oauth2"
+require "json"
+
+module OmniContacts
+  module Importer
+    class Facebook < Middleware::OAuth2
+
+      attr_reader :auth_host, :authorize_path, :auth_token_path, :scope
+
+      def initialize *args
+        super *args
+        @auth_host = 'graph.facebook.com'
+        @authorize_path = '/oauth/authorize'
+        @scope = 'email,user_relationships,user_birthday,friends_birthday'
+        @auth_token_path = '/oauth/access_token'
+        @contacts_host = 'graph.facebook.com'
+        @friends_path = '/me/friends'
+        @family_path = '/me/family'
+        @self_path = '/me'
+      end
+
+      def fetch_contacts_using_access_token access_token, access_token_secret
+        self_response = https_get(@contacts_host, @self_path, :access_token => access_token)
+        spouse_id = extract_spouse_id(self_response)
+        spouse_response = nil
+        if spouse_id
+          spouse_path = "/#{spouse_id}"
+          spouse_response = https_get(@contacts_host, spouse_path, {:access_token => access_token, :fields => 'first_name,last_name,name,id,gender,birthday,picture'})
+        end
+        family_response = https_get(@contacts_host, @family_path, {:access_token => access_token, :fields => 'first_name,last_name,name,id,gender,birthday,picture'})
+        friends_response = https_get(@contacts_host, @friends_path, {:access_token => access_token, :fields => 'first_name,last_name,name,id,gender,birthday,picture'})
+        contacts_from_response(spouse_response, family_response, friends_response)
+      end
+
+      private
+
+      def extract_spouse_id self_response
+        response = JSON.parse(self_response)
+        id = nil
+        if response['significant_other'] && response['relationship_status'] == 'Married'
+          id = response['significant_other']['id']
+        end
+        id
+      end
+
+      def contacts_from_response(spouse_response, family_response, friends_response)
+        contacts = []
+        family_ids = Set.new
+        if spouse_response
+          spouse_contact = create_contact_element(JSON.parse(spouse_response))
+          spouse_contact[:relation] = 'spouse'
+          contacts << spouse_contact
+          family_ids.add(spouse_contact[:id])
+        end
+        if family_response
+          family_response = JSON.parse(family_response)
+          family_response['data'].each do |family_contact|
+            contacts << create_contact_element(family_contact)
+            family_ids.add(family_contact['id'])
+          end
+        end
+        if friends_response
+          friends_response = JSON.parse(friends_response)
+          friends_response['data'].each do |friends_contact|
+            contacts << create_contact_element(friends_contact) unless family_ids.include?(friends_contact['id'])
+          end
+        end
+        contacts
+      end
+
+      def create_contact_element contact_info
+        # creating nil fields to keep the fields consistent across other networks
+        contact = {:id => nil, :first_name => nil, :last_name => nil, :name => nil, :email => nil, :gender => nil, :birthday => nil, :image_source => nil, :relation => nil}
+        contact[:id] = contact_info['id']
+        contact[:first_name] = normalize_name(contact_info['first_name'])
+        contact[:last_name] = normalize_name(contact_info['last_name'])
+        contact[:name] = contact_info['name']
+        contact[:email] = contact_info['email']
+        contact[:gender] = contact_info['gender']
+        birthday = contact_info['birthday'].split('/') if contact_info['birthday']
+        contact[:birthday] = birthday_format(birthday[0],birthday[1],birthday[2]) if birthday
+        contact[:image_source] = contact_info['picture']['data']['url'] if contact_info['picture']
+        contact[:relation] = contact_info['relationship']
+        contact
+      end
+
+      def escape_windows_format value
+        value.gsub(/[\r\s]/, '')
+      end
+
+    end
+  end
+end

--- a/lib/omnicontacts/importer/yahoo.rb
+++ b/lib/omnicontacts/importer/yahoo.rb
@@ -9,15 +9,15 @@ module OmniContacts
 
       def initialize *args
         super *args
-        @auth_host = "api.login.yahoo.com"
-        @auth_token_path = "/oauth/v2/get_request_token"
-        @auth_path = "/oauth/v2/request_auth"
-        @access_token_path = "/oauth/v2/get_token"
-        @contacts_host = "social.yahooapis.com"
+        @auth_host = 'api.login.yahoo.com'
+        @auth_token_path = '/oauth/v2/get_request_token'
+        @auth_path = '/oauth/v2/request_auth'
+        @access_token_path = '/oauth/v2/get_token'
+        @contacts_host = 'social.yahooapis.com'
       end
 
       def fetch_contacts_from_token_and_verifier auth_token, auth_token_secret, auth_verifier
-        (access_token, access_token_secret, guid) = fetch_access_token(auth_token, auth_token_secret, auth_verifier, ["xoauth_yahoo_guid"])
+        (access_token, access_token_secret, guid) = fetch_access_token(auth_token, auth_token_secret, auth_verifier, ['xoauth_yahoo_guid'])
         contacts_path = "/v1/user/#{guid}/contacts"
         contacts_response = http_get(@contacts_host, contacts_path, contacts_req_params(access_token, access_token_secret, contacts_path))
         contacts_from_response contacts_response
@@ -27,37 +27,52 @@ module OmniContacts
 
       def contacts_req_params access_token, access_token_secret, contacts_path
         params = {
-          :format => "json",
-          :oauth_consumer_key => consumer_key,
-          :oauth_nonce => encode(random_string),
-          :oauth_signature_method => "HMAC-SHA1",
-          :oauth_timestamp => timestamp,
-          :oauth_token => access_token,
-          :oauth_version => OmniContacts::Authorization::OAuth1::OAUTH_VERSION,
-          :view => "compact"
+            :format => 'json',
+            :oauth_consumer_key => consumer_key,
+            :oauth_nonce => encode(random_string),
+            :oauth_signature_method => 'HMAC-SHA1',
+            :oauth_timestamp => timestamp,
+            :oauth_token => access_token,
+            :oauth_version => OmniContacts::Authorization::OAuth1::OAUTH_VERSION,
+            :view => 'compact'
         }
         contacts_url = "http://#{@contacts_host}#{contacts_path}"
-        params["oauth_signature"] = oauth_signature("GET", contacts_url, params, access_token_secret)
+        params['oauth_signature'] = oauth_signature('GET', contacts_url, params, access_token_secret)
         params
       end
 
-      def contacts_from_response contacts_as_json
-        json = JSON.parse(contacts_as_json)
-        result = []
-        return result unless json["contacts"]["contact"]
-        json["contacts"]["contact"].each do |entry|
-          contact = {}
-          entry["fields"].each do |field|
-            contact[:email] = field["value"] if field["type"] == "email"
-            if field["type"] == "name"
-              name = field["value"]["givenName"]
-              surname = field["value"]["familyName"]
-              contact[:name] = "#{name} #{surname}" if name && surname
+      def contacts_from_response response_as_json
+        response = JSON.parse(response_as_json)
+        contacts = []
+        return contacts unless response['contacts']['contact']
+        response['contacts']['contact'].each do |entry|
+          # creating nil fields to keep the fields consistent across other networks
+          contact = {:id => nil, :first_name => nil, :last_name => nil, :name => nil, :email => nil, :gender => nil, :birthday => nil, :image_source => nil, :relation => nil}
+          yahoo_id = nil
+          contact[:id] = entry['id'].to_s
+          entry['fields'].each do |field|
+            if field['type'] == 'name'
+              contact[:first_name] = normalize_name(field['value']['givenName'])
+              contact[:last_name] = normalize_name(field['value']['familyName'])
+              contact[:name] = full_name(contact[:first_name],contact[:last_name])
+            end
+            contact[:email] = field['value'] if field['type'] == 'email'
+
+            if field['type'] == 'yahooid'
+              yahoo_id = field['value']
+            end
+
+            contact[:first_name], contact[:last_name], contact[:name] = email_to_name(contact[:email]) if contact[:name].nil? && contact[:email]
+            # contact[:first_name], contact[:last_name], contact[:name] = email_to_name(yahoo_id) if (yahoo_id && contact[:name].nil? && contact[:email].nil?)
+
+            if field['type'] == 'birthday'
+              contact[:birthday] = birthday_format(field['value']['month'], field['value']['day'],field['value']['year'])
             end
           end
-          result << contact if contact[:email]
+          contacts << contact if contact[:name]
         end
-        result
+        contacts.uniq! {|c| c[:email] || c[:name]}
+        contacts
       end
 
     end

--- a/spec/omnicontacts/authorization/oauth1_spec.rb
+++ b/spec/omnicontacts/authorization/oauth1_spec.rb
@@ -39,7 +39,7 @@ describe OmniContacts::Authorization::OAuth1 do
 
     it "should raise an error if request is invalid" do
       test_target.should_receive(:https_post).and_return("invalid_request")
-      expect { test_target.fetch_authorization_token }.should raise_error
+      expect { test_target.fetch_authorization_token }.to raise_error
     end
 
   end

--- a/spec/omnicontacts/authorization/oauth2_spec.rb
+++ b/spec/omnicontacts/authorization/oauth2_spec.rb
@@ -55,12 +55,12 @@ describe OmniContacts::Authorization::OAuth2 do
 
     it "should raise if the http request fails" do
       test_target.should_receive(:https_post).and_raise("Invalid code")
-      expect { test_target.fetch_access_token("code") }.should raise_error
+      expect { test_target.fetch_access_token("code") }.to raise_error
     end
 
     it "should raise an error if the JSON response contains an error field" do
       test_target.should_receive(:https_post).and_return(%[{"error": "error_message"}])
-      expect { test_target.fetch_access_token("code") }.should raise_error
+      expect { test_target.fetch_access_token("code") }.to raise_error
     end
   end
 

--- a/spec/omnicontacts/http_utils_spec.rb
+++ b/spec/omnicontacts/http_utils_spec.rb
@@ -67,7 +67,7 @@ describe OmniContacts::HTTPUtils do
       @connection.should_receive(:request_get).and_return(@response)
       @response.should_receive(:code).and_return("500")
       @response.should_receive(:body).and_return("some error message")
-      expect { @test_target.send(:https_get, "host", "path", {}) }.should raise_error
+      expect { @test_target.send(:https_get, "host", "path", {}) }.to raise_error
     end
   end
 end

--- a/spec/omnicontacts/importer/facebook_spec.rb
+++ b/spec/omnicontacts/importer/facebook_spec.rb
@@ -1,0 +1,58 @@
+require "spec_helper"
+require "omnicontacts/importer/facebook"
+
+describe OmniContacts::Importer::Facebook do
+
+  let(:facebook) { OmniContacts::Importer::Facebook.new({}, "client_id", "client_secret") }
+
+  let(:contacts_as_json) {
+    '{"data":[
+        {
+          "first_name":"John",
+          "last_name":"Smith",
+          "name":"John Smith",
+          "id":"608061886",
+          "gender":"male",
+          "birthday":"06/21",
+          "relationship":"cousin",
+          "picture":{"data":{"url":"http://profile.ak.fbcdn.net/hprofile-ak-snc6/186364_608061886_2089044200_q.jpg","is_silhouette":false}}
+        }
+      ]
+    }' }
+
+  describe "fetch_contacts_using_access_token" do
+    let(:token) { "token" }
+    let(:token_type) { "token_type" }
+
+
+    it "should request the contacts by providing the token in the url and fields params only for family and friends requests" do
+      facebook.should_receive(:https_get) do |host, path, params, headers|
+        params[:access_token].should eq(token)
+        params[:fields].should be_nil
+        contacts_as_json
+      end
+      facebook.should_receive(:https_get) do |host, path, params, headers|
+        params[:access_token].should eq(token)
+        params[:fields].should eq('first_name,last_name,name,id,gender,birthday,picture')
+        contacts_as_json
+      end.at_most(2).times
+      facebook.fetch_contacts_using_access_token token, token_type
+    end
+
+    it "should correctly parse id, name,email,gender, birthday, image source and relation" do
+      3.times { facebook.should_receive(:https_get).and_return(contacts_as_json) }
+      result = facebook.fetch_contacts_using_access_token token, token_type
+      result.size.should be(1)
+      result.first[:id].should eq('608061886')
+      result.first[:first_name].should eq('John')
+      result.first[:last_name].should eq('Smith')
+      result.first[:name].should eq('John Smith')
+      result.first[:email].should be_nil
+      result.first[:gender].should eq('male')
+      result.first[:birthday].should eq({:day=>21, :month=>06, :year=>nil})
+      result.first[:image_source].should eq('http://profile.ak.fbcdn.net/hprofile-ak-snc6/186364_608061886_2089044200_q.jpg')
+      result.first[:relation].should eq('cousin')
+    end
+  end
+
+end

--- a/spec/omnicontacts/importer/gmail_spec.rb
+++ b/spec/omnicontacts/importer/gmail_spec.rb
@@ -5,24 +5,66 @@ describe OmniContacts::Importer::Gmail do
 
   let(:gmail) { OmniContacts::Importer::Gmail.new({}, "client_id", "client_secret") }
 
-  let(:contacts_as_xml) {
-    "<entry xmlns:gd='http://schemas.google.com/g/2005'>
-       <gd:name>
-         <gd:fullName>Edward Bennet</gd:fullName>
-       </gd:name>
-       <gd:email rel='http://schemas.google.com/g/2005#work' primary='true' address='bennet@gmail.com'/>
-     </entry>"
-  }
+  let(:contacts_as_json) {
+    '{"version":"1.0","encoding":"UTF-8",
+        "feed":{
+          "xmlns":"http://www.w3.org/2005/Atom",
+          "xmlns$openSearch":"http://a9.com/-/spec/opensearch/1.1/",
+          "xmlns$gContact":"http://schemas.google.com/contact/2008",
+          "xmlns$batch":"http://schemas.google.com/gdata/batch",
+          "xmlns$gd":"http://schemas.google.com/g/2005",
+          "gd$etag":"W/\"C0YHRno7fSt7I2A9WhBSQ0Q.\"",
 
-  let(:contact_without_fullname) {
-    "<entry xmlns:gd='http://schemas.google.com/g/2005'>
-       <gd:name/>
-       <gd:email rel='http://schemas.google.com/g/2005#work' primary='true' address='bennet@gmail.com'/>
-     </entry>"
+          "id":{"$t":"logged_in_user@gmail.com"},
+          "updated":{"$t":"2013-02-20T20:12:17.405Z"},
+          "category":[{
+            "scheme":"http://schemas.google.com/g/2005#kind",
+            "term":"http://schemas.google.com/contact/2008#contact"
+           }],
+
+          "title":{"$t":"Users\'s Contacts"},
+          "link":[
+            {"rel":"alternate","type":"text/html","href":"http://www.google.com/"},
+            {"rel":"http://schemas.google.com/g/2005#feed","type":"application/atom+xml","href":"https://www.google.com/m8/feeds/contacts/logged_in_user%40gmail.com/full"},
+            {"rel":"http://schemas.google.com/g/2005#post","type":"application/atom+xml","href":"https://www.google.com/m8/feeds/contacts/logged_in_user%40gmail.com/full"},
+            {"rel":"http://schemas.google.com/g/2005#batch","type":"application/atom+xml","href":"https://www.google.com/m8/feeds/contacts/logged_in_user%40gmail.com/full/batch"},
+            {"rel":"self","type":"application/atom+xml","href":"https://www.google.com/m8/feeds/contacts/logged_in_user%40gmail.com/full?alt\u003djson\u0026max-results\u003d1"},
+            {"rel":"next","type":"application/atom+xml","href":"https://www.google.com/m8/feeds/contacts/logged_in_user%40gmail.com/full?alt\u003djson\u0026start-index\u003d2\u0026max-results\u003d1"}
+          ],
+          "author":[{"name":{"$t":"Asma"},"email":{"$t":"logged_in_user@gmail.com"}}],
+          "generator":{"version":"1.0","uri":"http://www.google.com/m8/feeds","$t":"Contacts"},
+          "openSearch$totalResults":{"$t":"1007"},
+          "openSearch$startIndex":{"$t":"1"},
+          "openSearch$itemsPerPage":{"$t":"1"},
+          "entry":[
+            {
+            "gd$etag":"\"R3oyfDVSLyt7I2A9WhBTSEULRA0.\"",
+            "id":{"$t":"http://www.google.com/m8/feeds/contacts/logged_in_user%40gmail.com/base/1"},
+            "updated":{"$t":"2013-02-14T22:36:36.494Z"},
+            "app$edited":{"xmlns$app":"http://www.w3.org/2007/app","$t":"2013-02-14T22:36:36.494Z"},
+            "category":[{"scheme":"http://schemas.google.com/g/2005#kind","term":"http://schemas.google.com/contact/2008#contact"}],
+            "title":{"$t":"Edward Bennet"},
+            "link":[
+              {"rel":"http://schemas.google.com/contacts/2008/rel#photo","type":"image/*","href":"https://www.google.com/m8/feeds/photos/media/logged_in_user%40gmail.com/1"},
+              {"rel":"self","type":"application/atom+xml","href":"https://www.google.com/m8/feeds/contacts/logged_in_user%40gmail.com/full/1"},
+              {"rel":"edit","type":"application/atom+xml","href":"https://www.google.com/m8/feeds/contacts/logged_in_user%40gmail.com/full/1"}
+            ],
+            "gd$name":{
+              "gd$fullName":{"$t":"Edward Bennet"},
+              "gd$givenName":{"$t":"Edward"},
+              "gd$familyName":{"$t":"Bennet"}
+            },
+            "gContact$birthday":{"when":"1954-07-02"},
+            "gContact$relation":{"rel":"father"},
+            "gContact$gender":{"value":"male"},
+            "gd$email":[{"rel":"http://schemas.google.com/g/2005#other","address":"bennet@gmail.com","primary":"true"}],
+            "gContact$groupMembershipInfo":[{"deleted":"false","href":"http://www.google.com/m8/feeds/groups/logged_in_user%40gmail.com/base/6"}]
+          }]
+        }
+      }'
   }
 
   describe "fetch_contacts_using_access_token" do
-
     let(:token) { "token" }
     let(:token_type) { "token_type" }
 
@@ -30,25 +72,23 @@ describe OmniContacts::Importer::Gmail do
       gmail.should_receive(:https_get) do |host, path, params, headers|
         headers["GData-Version"].should eq("3.0")
         headers["Authorization"].should eq("#{token_type} #{token}")
-        contacts_as_xml
+        contacts_as_json
       end
       gmail.fetch_contacts_using_access_token token, token_type
     end
 
-    it "should correctly parse name and email" do
-      gmail.should_receive(:https_get).and_return(contacts_as_xml)
+    it "should correctly parse id, name,email,gender, birthday, image source and relation" do
+      gmail.should_receive(:https_get).and_return(contacts_as_json)
       result = gmail.fetch_contacts_using_access_token token, token_type
       result.size.should be(1)
+      result.first[:id].should eq('http://www.google.com/m8/feeds/contacts/logged_in_user%40gmail.com/base/1')
+      result.first[:first_name].should eq('Edward')
+      result.first[:last_name].should eq('Bennet')
       result.first[:name].should eq("Edward Bennet")
       result.first[:email].should eq("bennet@gmail.com")
-    end
-
-    it "should handle contact without fullname" do
-      gmail.should_receive(:https_get).and_return(contact_without_fullname)
-      result = gmail.fetch_contacts_using_access_token token, token_type
-      result.size.should be(1)
-      result.first[:name].should be_nil
-      result.first[:email].should eq("bennet@gmail.com")
+      result.first[:gender].should eq("male")
+      result.first[:birthday].should eq({:day=>02, :month=>07, :year=>1954})
+      result.first[:relation].should eq('father')
     end
 
   end

--- a/spec/omnicontacts/importer/hotmail_spec.rb
+++ b/spec/omnicontacts/importer/hotmail_spec.rb
@@ -6,21 +6,23 @@ describe OmniContacts::Importer::Hotmail do
   let(:hotmail) { OmniContacts::Importer::Hotmail.new({}, "client_id", "client_secret") }
 
   let(:contacts_as_json) {
-    "{
-       \"data\":
-       [{
-       \"id\": \"contact.b4466224b2ca42798c3d4ea90c75aa56\", 
-       \"first_name\": null, 
-       \"last_name\": null, 
-       \"name\": \"henrik@hotmail.com\", 
-       \"gender\": null, 
-       \"is_friend\": false,
-       \"is_favorite\": false,  
-       \"user_id\": null, 
-       \"birth_day\": 29, 
-       \"birth_month\": 3 
-       }]
-    }" }
+    '{
+   "data": [
+       {
+         "id": "contact.7fac34bb000000000000000000000000",
+         "first_name": "John",
+         "last_name": "Smith",
+         "name": "John Smith",
+         "gender": null,
+         "user_id": "123456",
+         "is_friend": false,
+         "is_favorite": false,
+         "birth_day": 5,
+         "birth_month": 6,
+         "birth_year":1952
+      }
+    ]}'
+  }
 
   describe "fetch_contacts_using_access_token" do
 
@@ -35,12 +37,19 @@ describe OmniContacts::Importer::Hotmail do
       hotmail.fetch_contacts_using_access_token token, token_type
     end
 
-    it "should correctly parse the contacts" do
+    it "should correctly parse id, name,email,gender, birthday, image source and relation" do
       hotmail.should_receive(:https_get).and_return(contacts_as_json)
       result = hotmail.fetch_contacts_using_access_token token, token_type
       result.size.should be(1)
-      result.first[:name].should be_nil
-      result.first[:email].should eq("henrik@hotmail.com")
+      result.first[:id].should eq('123456')
+      result.first[:first_name].should eq("John")
+      result.first[:last_name].should eq('Smith')
+      result.first[:name].should eq("John Smith")
+      result.first[:email].should be_nil
+      result.first[:gender].should be_nil
+      result.first[:birthday].should eq({:day=>5, :month=>6, :year=>1952})
+      result.first[:image_source].should eq('https://apis.live.net/v5.0/123456/picture')
+      result.first[:relation].should be_nil
     end
   end
 

--- a/spec/omnicontacts/importer/yahoo_spec.rb
+++ b/spec/omnicontacts/importer/yahoo_spec.rb
@@ -5,11 +5,23 @@ describe OmniContacts::Importer::Yahoo do
 
   describe "fetch_contacts_from_token_and_verifier" do
     let(:contacts_as_json) {
-      '{"contacts": 
-      {"start":1, "count":1, 
-      "contact":[{"id":10, "fields":[{"id":819, "type":"email", "value":"john@yahoo.com"},
-       {"type":"name", "value": { "givenName":"John", "familyName":"Doe"} }] }] 
-    } }' }
+      '{
+        "contacts": {
+          "start":1,
+          "count":1,
+          "contact":[
+            {
+              "id":10,
+              "fields":[
+                {"id":819, "type":"email", "value":"johnny@yahoo.com"},
+                {"id":806,"type":"name","value":{"givenName":"John","middleName":"","familyName":"Smith"},"editedBy":"OWNER","categories":[]},
+                {"id":33555343,"type":"guid","value":"7ET6MYV2UQ6VR6CBSNMCLFJIVI"},
+                {"id":946,"type":"birthday","value":{"day":"22","month":"2","year":"1952"},"editedBy":"OWNER","categories":[]}
+              ]
+            }
+          ]
+        }
+      }' }
 
     let(:yahoo) { OmniContacts::Importer::Yahoo.new({}, "consumer_key", "consumer_secret") }
 
@@ -29,13 +41,19 @@ describe OmniContacts::Importer::Yahoo do
       yahoo.fetch_contacts_from_token_and_verifier "auth_token", "auth_token_secret", "oauth_verifier"
     end
 
-    it "should parse the contacts correctly" do
+    it "should correctly parse id, name,email,gender, birthday, image source and relation" do
       yahoo.should_receive(:fetch_access_token).and_return(["access_token", "access_token_secret", "guid"])
       yahoo.should_receive(:http_get).and_return(contacts_as_json)
       result = yahoo.fetch_contacts_from_token_and_verifier "auth_token", "auth_token_secret", "oauth_verifier"
       result.size.should be(1)
-      result.first[:name].should eq("John Doe")
-      result.first[:email].should eq("john@yahoo.com")
+      result.first[:id].should eq('10')
+      result.first[:first_name].should eq('John')
+      result.first[:last_name].should eq('Smith')
+      result.first[:name].should eq("John Smith")
+      result.first[:email].should eq("johnny@yahoo.com")
+      result.first[:gender].should be_nil
+      result.first[:birthday].should eq({:day=>22, :month=>2, :year=>1952})
+      result.first[:relation].should be_nil
     end
 
     it "should return an empty list of contacts" do
@@ -44,7 +62,6 @@ describe OmniContacts::Importer::Yahoo do
       yahoo.should_receive(:http_get).and_return(empty_contacts_list)
       result = yahoo.fetch_contacts_from_token_and_verifier "auth_token", "auth_token_secret", "oauth_verifier"
       result.should be_empty
-
     end
 
   end

--- a/spec/omnicontacts/integration_test_spec.rb
+++ b/spec/omnicontacts/integration_test_spec.rb
@@ -45,7 +45,7 @@ describe IntegrationTest do
     
     it "should throw an exception" do
       IntegrationTest.instance.mock('test', :some_error)
-      expect {IntegrationTest.instance.mock_fetch_contacts(@provider)}.should raise_error
+      expect {IntegrationTest.instance.mock_fetch_contacts(@provider)}.to raise_error
     end
   end
 end


### PR DESCRIPTION
Features/Changes Made: 
- Added Facebook Contacts Import. 
- Retrieved additional parameters from contacts from all the networks (facebook, gmail, yahoo, hotmail): 
  It now fetches: 
  1. name
  2. first name
  3. last name
  4. email 
  5. gender
  6. birthday 
  7. relation
  8. id
  9. profile image (only for facebook and hotmail for now)
- Fetch gmail response in json format instead of xml. This is to make it consistent with response formats from other networks. 
- Updated https_get headers default parameter to make it compatible with Ruby 2.0
- Raise_error matcher updated to latest Rspec specifications. 
- All importer specs updated to test the latest code.
