### PR TITLE
Add parsing of snailmail addresses, for GMail and Yahoo

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The following table shows which fields are supported by which provider:
 		<td></td>
 		<td>X</td>
 		<td></td>
-		<td></td>
+		<td>X</td>
   </tr>
 
   <tr>
@@ -120,7 +120,7 @@ The following table shows which fields are supported by which provider:
 		<td></td>
 		<td>X</td>
 		<td></td>
-		<td></td>
+		<td>X</td>
   </tr>
 
   <tr>
@@ -128,7 +128,7 @@ The following table shows which fields are supported by which provider:
 		<td></td>
 		<td>X</td>
 		<td></td>
-		<td></td>
+		<td>X</td>
   </tr>
 
   <tr>
@@ -136,7 +136,7 @@ The following table shows which fields are supported by which provider:
 		<td></td>
 		<td>X</td>
 		<td></td>
-		<td></td>
+		<td>X</td>
   </tr>
 
   <tr>
@@ -144,7 +144,7 @@ The following table shows which fields are supported by which provider:
 		<td></td>
 		<td>X</td>
 		<td></td>
-		<td></td>
+		<td>X</td>
   </tr>
 
   <tr>
@@ -172,6 +172,8 @@ The following table shows which fields are supported by which provider:
   </tr>
 
 </table>
+
+Note: :region is where something like a US state or Canadian province would go, and similarly the :postcode is for a US ZIP code or similar foreign code.
 
 Obviously it may happen that some fields are blank even if supported by the provider in the case that the contact did not provide any information about them.
 

--- a/lib/omnicontacts/importer/gmail.rb
+++ b/lib/omnicontacts/importer/gmail.rb
@@ -79,11 +79,15 @@ module OmniContacts
           if address
             contact[:address_1] = address['gd$street']['$t'] if address['gd$street']
             contact[:address_1] = address['gd$formattedAddress']['$t'] if contact[:address_1].nil? && address['gd$formattedAddress']
-            # gmail doesn't parse the street address into two lines, so no contact[:address_2]
+            if contact[:address_1].index("\n")
+              parts = contact[:address_1].split("\n")
+              contact[:address_1] = parts.first
+              # this may contain city/state/zip if user jammed it all into one string.... :-(
+              contact[:address_2] = parts[1..-1].join(', ')
+            end
             contact[:city] = address['gd$city']['$t'] if address['gd$city']
             contact[:region] = address['gd$region']['$t'] if address['gd$region'] # like state or province
             contact[:postcode] = address['gd$postcode']['$t'] if address['gd$postcode']
-            puts "Address of #{contact[:first_name]} #{contact[:last_name]}: #{contact[:address_1]}, #{contact[:city]}, #{contact[:region]} #{contact[:postcode]}"
           end
 
           contacts << contact if contact[:name]

--- a/spec/omnicontacts/importer/gmail_spec.rb
+++ b/spec/omnicontacts/importer/gmail_spec.rb
@@ -58,7 +58,8 @@ describe OmniContacts::Importer::Gmail do
             "gContact$relation":{"rel":"father"},
             "gContact$gender":{"value":"male"},
             "gd$email":[{"rel":"http://schemas.google.com/g/2005#other","address":"bennet@gmail.com","primary":"true"}],
-            "gContact$groupMembershipInfo":[{"deleted":"false","href":"http://www.google.com/m8/feeds/groups/logged_in_user%40gmail.com/base/6"}]
+            "gContact$groupMembershipInfo":[{"deleted":"false","href":"http://www.google.com/m8/feeds/groups/logged_in_user%40gmail.com/base/6"}],
+            "gd$structuredPostalAddress":[{"rel":"http://schemas.google.com/g/2005#home", "gd$formattedAddress":{"$t":"1313 Trashview Court\nApt. 13\nNowheresville, OK 66666"}, "gd$street":{"$t":"1313 Trashview Court\nApt. 13"}, "gd$postcode":{"$t":"66666"}, "gd$city":{"$t":"Nowheresville"}, "gd$region":{"$t":"OK"}}]
           }]
         }
       }'
@@ -77,7 +78,7 @@ describe OmniContacts::Importer::Gmail do
       gmail.fetch_contacts_using_access_token token, token_type
     end
 
-    it "should correctly parse id, name,email,gender, birthday, image source and relation" do
+    it "should correctly parse id, name,email,gender, birthday, image source, snailmail address, and relation" do
       gmail.should_receive(:https_get).and_return(contacts_as_json)
       result = gmail.fetch_contacts_using_access_token token, token_type
       result.size.should be(1)
@@ -88,6 +89,11 @@ describe OmniContacts::Importer::Gmail do
       result.first[:email].should eq("bennet@gmail.com")
       result.first[:gender].should eq("male")
       result.first[:birthday].should eq({:day=>02, :month=>07, :year=>1954})
+      result.first[:address_1].should eq('1313 Trashview Court')
+      result.first[:address_2].should eq('Apt. 13')
+      result.first[:city].should eq('Nowheresville')
+      result.first[:region].should eq('OK')
+      result.first[:postcode].should eq('66666')
       result.first[:relation].should eq('father')
     end
 

--- a/spec/omnicontacts/importer/yahoo_spec.rb
+++ b/spec/omnicontacts/importer/yahoo_spec.rb
@@ -16,7 +16,9 @@ describe OmniContacts::Importer::Yahoo do
                 {"id":819, "type":"email", "value":"johnny@yahoo.com"},
                 {"id":806,"type":"name","value":{"givenName":"John","middleName":"","familyName":"Smith"},"editedBy":"OWNER","categories":[]},
                 {"id":33555343,"type":"guid","value":"7ET6MYV2UQ6VR6CBSNMCLFJIVI"},
-                {"id":946,"type":"birthday","value":{"day":"22","month":"2","year":"1952"},"editedBy":"OWNER","categories":[]}
+                {"id":946,"type":"birthday","value":{"day":"22","month":"2","year":"1952"},"editedBy":"OWNER","categories":[]},
+                {"id":21, "type":"address", "value":{"street":"1313 Trashview Court\nApt. 13", "city":"Nowheresville", "stateOrProvince":"OK", "postalCode":"66666", "country":"", "countryCode":""}, "editedBy":"OWNER", "flags":["HOME"], "categories":[]}
+                
               ]
             }
           ]
@@ -41,7 +43,7 @@ describe OmniContacts::Importer::Yahoo do
       yahoo.fetch_contacts_from_token_and_verifier "auth_token", "auth_token_secret", "oauth_verifier"
     end
 
-    it "should correctly parse id, name,email,gender, birthday, image source and relation" do
+    it "should correctly parse id, name,email,gender, birthday, image source, snailmail address, and relation" do
       yahoo.should_receive(:fetch_access_token).and_return(["access_token", "access_token_secret", "guid"])
       yahoo.should_receive(:http_get).and_return(contacts_as_json)
       result = yahoo.fetch_contacts_from_token_and_verifier "auth_token", "auth_token_secret", "oauth_verifier"
@@ -53,6 +55,11 @@ describe OmniContacts::Importer::Yahoo do
       result.first[:email].should eq("johnny@yahoo.com")
       result.first[:gender].should be_nil
       result.first[:birthday].should eq({:day=>22, :month=>2, :year=>1952})
+      result.first[:address_1].should eq('1313 Trashview Court')
+      result.first[:address_2].should eq('Apt. 13')
+      result.first[:city].should eq('Nowheresville')
+      result.first[:region].should eq('OK')
+      result.first[:postcode].should eq('66666')
       result.first[:relation].should be_nil
     end
 


### PR DESCRIPTION
This pull request adds snailmail address components (address_1, address_2, city, region, and postcode) to the pieces OmniContacts will parse upon retrieving contacts from GMail or Yahoo (but not Facebook or Hotmail).  Region is intended to be the state, province, or whatever else the country may be divided into at a top level.  Postcode is zip code or non-US equivalent.  It does NOT currently parse the country -- I was doing this on a client's dime and he didn't need that, but someone could easily add it later.

It also:
- adds tests for this functionality,
- makes a chunk of code I had to modify anyway a bit more Ruby-idiomatic and efficient,
- updates the README a bit, and
- turns the feature/provider table sideways, so that more features can be added to it without running out of room.  :-)
