### PR TITLE
Extract email_hashes array for Hotmail

### DIFF
--- a/lib/omnicontacts/importer/hotmail.rb
+++ b/lib/omnicontacts/importer/hotmail.rb
@@ -39,7 +39,7 @@ module OmniContacts
         contacts = []
         response['data'].each do |entry|
           # creating nil fields to keep the fields consistent across other networks
-          contact = {:id => nil, :first_name => nil, :last_name => nil, :name => nil, :email => nil, :gender => nil, :birthday => nil, :profile_picture=> nil, :relation => nil}
+          contact = {:id => nil, :first_name => nil, :last_name => nil, :name => nil, :email => nil, :gender => nil, :birthday => nil, :profile_picture=> nil, :relation => nil, :email_hashes => []}
           contact[:id] = entry['user_id'] ? entry['user_id'] : entry['id']
           if valid_email? entry["name"]
             contact[:email] = entry["name"]
@@ -52,6 +52,7 @@ module OmniContacts
           contact[:birthday] = birthday_format(entry['birth_month'], entry['birth_day'], entry['birth_year'])
           contact[:gender] = entry['gender']
           contact[:profile_picture] = 'https://apis.live.net/v5.0/' + entry['user_id'] + '/picture' if entry['user_id']
+          contact[:email_hashes] = entry['email_hashes']
           contacts << contact if contact[:name] || contact[:first_name]
         end
         contacts

--- a/spec/omnicontacts/importer/hotmail_spec.rb
+++ b/spec/omnicontacts/importer/hotmail_spec.rb
@@ -33,7 +33,8 @@ describe OmniContacts::Importer::Hotmail do
          "is_favorite": false,
          "birth_day": 5,
          "birth_month": 6,
-         "birth_year":1952
+         "birth_year":1952,
+         "email_hashes":["1234567890"]
       }
     ]}'
   }
@@ -60,7 +61,7 @@ describe OmniContacts::Importer::Hotmail do
       hotmail.fetch_contacts_using_access_token token, token_type
     end
 
-    it "should correctly parse id, name,email,gender, birthday, profile picture and relation" do
+    it "should correctly parse id, name, email, gender, birthday, profile picture, relation and email hashes" do
       hotmail.should_receive(:https_get).and_return(self_response)
       hotmail.should_receive(:https_get).and_return(contacts_as_json)
       result = hotmail.fetch_contacts_using_access_token token, token_type
@@ -75,6 +76,7 @@ describe OmniContacts::Importer::Hotmail do
       result.first[:birthday].should eq({:day=>5, :month=>6, :year=>1952})
       result.first[:profile_picture].should eq('https://apis.live.net/v5.0/123456/picture')
       result.first[:relation].should be_nil
+      result.first[:email_hashes].should eq(["1234567890"])
     end
 
     it "should correctly parse and set logged in user information" do


### PR DESCRIPTION
Hotmail does not give email addresses for a contact, but just email hashes.

We can check if email hashes match by calculating the hash for an email with the following algorithm:

``` ruby
Digest::SHA256.hexdigest((email + client_id).downcase).downcase
```
