### PR TITLE
Hotmail Importer - allow configurable permissions

### DIFF
--- a/lib/omnicontacts/importer/hotmail.rb
+++ b/lib/omnicontacts/importer/hotmail.rb
@@ -9,11 +9,11 @@ module OmniContacts
 
       attr_reader :auth_host, :authorize_path, :auth_token_path, :scope
 
-      def initialize *args
-        super *args
+      def initialize app, client_id, client_secret, options ={}
+        super app, client_id, client_secret, options
         @auth_host = "oauth.live.com"
         @authorize_path = "/authorize"
-        @scope = "wl.signin, wl.basic, wl.birthday , wl.emails ,wl.contacts_birthday , wl.contacts_photos"
+        @scope = options[:permissions] || "wl.signin, wl.basic, wl.birthday , wl.emails ,wl.contacts_birthday , wl.contacts_photos"
         @auth_token_path = "/token"
         @contacts_host = "apis.live.net"
         @contacts_path = "/v5.0/me/contacts"

--- a/spec/omnicontacts/importer/hotmail_spec.rb
+++ b/spec/omnicontacts/importer/hotmail_spec.rb
@@ -3,7 +3,8 @@ require "omnicontacts/importer/hotmail"
 
 describe OmniContacts::Importer::Hotmail do
 
-  let(:hotmail) { OmniContacts::Importer::Hotmail.new({}, "client_id", "client_secret") }
+  let(:permissions) { "perm1, perm2" }
+  let(:hotmail) { OmniContacts::Importer::Hotmail.new({}, "client_id", "client_secret", {:permissions => permissions}) }
 
   let(:self_response) {
     '{
@@ -45,7 +46,7 @@ describe OmniContacts::Importer::Hotmail do
     let(:token_type) { "token_type" }
 
     before(:each) do
-      hotmail.instance_variable_set(:@env, {})
+      hotmail.instance_variable_set(:@env, {"HTTP_HOST" => "http://example.com"})
     end
 
     it "should request the contacts by providing the token in the url" do
@@ -59,6 +60,10 @@ describe OmniContacts::Importer::Hotmail do
         contacts_as_json
       end
       hotmail.fetch_contacts_using_access_token token, token_type
+    end
+
+    it "should set requested permissions in the authorization url" do
+      hotmail.authorization_url.should match(/scope=#{Regexp.quote(CGI.escape(permissions))}/)
     end
 
     it "should correctly parse id, name, email, gender, birthday, profile picture, relation and email hashes" do


### PR DESCRIPTION
This allows the application to request different permissions, so that
the user is not confronted with a long list of things to approve. E.g.
if the application is only interested in reading contacts, we can do:

``` ruby
Rails.application.middleware.use OmniContacts::Builder do
  importer :hotmail, 'application_id', 'secret_key',
    :permissions => "wl.basic,wl.emails"
end
```
