### PR TITLE
Support state param for callback

### DIFF
--- a/lib/omnicontacts/middleware/base_oauth.rb
+++ b/lib/omnicontacts/middleware/base_oauth.rb
@@ -104,6 +104,15 @@ module OmniContacts
         "omnicontacts." + class_name
       end
 
+      def append_state_query(target_url)
+        state = Rack::Utils.parse_query(@env['QUERY_STRING'])['state']
+
+        unless state.nil?
+          target_url = target_url + (target_url.include?("?")?"&":"?") + 'state=' + state
+        end
+
+        return target_url
+      end
     end
   end
 end

--- a/lib/omnicontacts/middleware/oauth1.rb
+++ b/lib/omnicontacts/middleware/oauth1.rb
@@ -43,7 +43,9 @@ module OmniContacts
       end
 
       def redirect_to_authorization_site auth_token
-        [302, {"Content-Type" => "application/x-www-form-urlencoded", "location" => authorization_url(auth_token)}, []]
+        authorization_url = authorization_url(auth_token)
+        target_url = append_state_query(authorization_url)
+        [302, {"Content-Type" => "application/x-www-form-urlencoded", "location" => target_url}, []]
       end
 
       # Parses the authorization token from the query string and 

--- a/lib/omnicontacts/middleware/oauth2.rb
+++ b/lib/omnicontacts/middleware/oauth2.rb
@@ -24,7 +24,8 @@ module OmniContacts
       end
 
       def request_authorization_from_user
-        [302, {"Content-Type" => "application/x-www-form-urlencoded", "location" => authorization_url}, []]
+        target_url = append_state_query(authorization_url)
+        [302, {"location" => target_url}, []]
       end
 
       def redirect_uri

--- a/spec/omnicontacts/middleware/oauth1_spec.rb
+++ b/spec/omnicontacts/middleware/oauth1_spec.rb
@@ -46,6 +46,12 @@ describe OmniContacts::Middleware::OAuth1 do
       last_response.headers['location'].should eq("http://www.example.com")
     end
 
+    it "should pass through state query params visiting the listening path" do
+      OAuth1Middleware.mock_auth_token_resp.should_receive(:body).and_return(["auth_token", "auth_token_secret"])
+      get "#{ MOUNT_PATH }oauth1middleware?state=/parent/resource/id"
+      last_response.headers['location'].should eq("http://www.example.com?state=/parent/resource/id")
+    end
+
     it "should redirect to failure url if fetching the request token does not succeed" do
       OAuth1Middleware.mock_auth_token_resp.should_receive(:body).and_raise("Request failed")
       get "contacts/oauth1middleware"

--- a/spec/omnicontacts/middleware/oauth2_spec.rb
+++ b/spec/omnicontacts/middleware/oauth2_spec.rb
@@ -44,6 +44,11 @@ describe OmniContacts::Middleware::OAuth2 do
       last_response.should be_redirect
       last_response.headers['location'].should eq("http://www.example.com")
     end
+
+    it "should pass through state query params visiting the listening path" do
+      get "#{ MOUNT_PATH }oauth2middleware?state=/parent/resource/id"
+      last_response.headers['location'].should eq("http://www.example.com?state=/parent/resource/id")
+    end
   end
 
   context "visiting the callback url after authorization" do


### PR DESCRIPTION
Hi

I took inspiration from https://github.com/Diego81/omnicontacts/issues/44

I needed the state param on the OAuth2 request to Google ... so I wasn't entirely sure on the OAuth1 changes ... the code changes on the issue above for OAuth1 seemed very different and so I went with what seemed correct based on the specs I added.

I also wanted to only add the state param if one was included in the query string otherwise state= was being added unnecessarily.

Anyways ... let me know what you think and I can make changes.

Cheers
Shane
