### PR TITLE
Also support passing through state param for failure callback

### DIFF
--- a/lib/omnicontacts/middleware/base_oauth.rb
+++ b/lib/omnicontacts/middleware/base_oauth.rb
@@ -88,7 +88,9 @@ module OmniContacts
 
       def handle_error error_type, exception
         logger.puts("Error #{error_type} while processing #{@env["PATH_INFO"]}: #{exception.message}") if logger
-        [302, {"Content-Type" => "text/html", "location" => "#{ MOUNT_PATH }failure?error_message=#{error_type}&importer=#{class_name}"}, []]
+        failure_url = "#{ MOUNT_PATH }failure?error_message=#{error_type}&importer=#{class_name}"
+        target_url = append_state_query(failure_url)
+        [302, {"Content-Type" => "text/html", "location" => target_url}, []]
       end
 
       def session

--- a/spec/omnicontacts/middleware/base_oauth_spec.rb
+++ b/spec/omnicontacts/middleware/base_oauth_spec.rb
@@ -39,6 +39,12 @@ describe OmniContacts::Middleware::BaseOAuth do
     last_response.headers["location"].should eq("#{ MOUNT_PATH }failure?error_message=internal_error&importer=testprovider")
   end
   
+  it "should pass through state query params to the failure url" do
+    OmniContacts.integration_test.mock(:testprovider, "some_error" )
+    get "#{MOUNT_PATH }testprovider/callback?state=/parent/resource/id"
+    last_response.headers["location"].should eq("#{ MOUNT_PATH }failure?error_message=internal_error&importer=testprovider&state=/parent/resource/id")
+  end
+  
   after(:all) do 
     OmniContacts.integration_test.enabled = false
     OmniContacts.integration_test.clear_mocks


### PR DESCRIPTION
Hi

Sorry, I probably should have thought about this more when doing the other change but I was so focussed on the success callback I failed to consider that I would also like to return the application state for the error callback too.

Thanks
Shane
