### PR TITLE
Fix hotmail contacts couldn't be fetched sometimes

### DIFF
--- a/lib/omnicontacts/importer/hotmail.rb
+++ b/lib/omnicontacts/importer/hotmail.rb
@@ -11,10 +11,10 @@ module OmniContacts
 
       def initialize app, client_id, client_secret, options ={}
         super app, client_id, client_secret, options
-        @auth_host = "oauth.live.com"
-        @authorize_path = "/authorize"
-        @scope = options[:permissions] || "wl.signin, wl.basic, wl.birthday , wl.emails ,wl.contacts_birthday , wl.contacts_photos"
-        @auth_token_path = "/token"
+        @auth_host = "login.live.com"
+        @authorize_path = "/oauth20_authorize.srf"
+        @scope = options[:permissions] || "wl.signin, wl.basic, wl.birthday , wl.emails ,wl.contacts_birthday , wl.contacts_photos, wl.contacts_emails"
+        @auth_token_path = "/oauth20_token.srf"
         @contacts_host = "apis.live.net"
         @contacts_path = "/v5.0/me/contacts"
         @self_path = "/v5.0/me"
@@ -48,6 +48,7 @@ module OmniContacts
             contact[:first_name] = normalize_name(entry['first_name'])
             contact[:last_name] = normalize_name(entry['last_name'])
             contact[:name] = normalize_name(entry['name'])
+            contact[:email] = parse_email(entry['emails'])
           end
           contact[:birthday] = birthday_format(entry['birth_month'], entry['birth_day'], entry['birth_year'])
           contact[:gender] = entry['gender']
@@ -60,7 +61,7 @@ module OmniContacts
 
       def parse_email(emails)
         return nil if emails.nil?
-        emails['account']
+        emails['account'] || emails['preferred'] || emails['personal'] || emails['business'] || emails['other']
       end
 
       def current_user me

--- a/lib/omnicontacts/middleware/oauth2.rb
+++ b/lib/omnicontacts/middleware/oauth2.rb
@@ -5,7 +5,7 @@ require "omnicontacts/middleware/base_oauth"
 #
 # Extending class are required to implement
 # the following methods:
-# * fetch_contacts_using_access_token -> it 
+# * fetch_contacts_using_access_token -> it
 #   fetches the list of contacts from the authorization
 #   server.
 module OmniContacts
@@ -34,7 +34,7 @@ module OmniContacts
 
       # It extract the authorization code from the query string.
       # It uses it to obtain an access token.
-      # If the authorization code has a refresh token associated 
+      # If the authorization code has a refresh token associated
       # with it in the session, it uses the obtain an access token.
       # It fetches the list of contacts and stores the refresh token
       # associated with the access token in the session.


### PR DESCRIPTION
If the name of a hotmail contact isn't a valid email format, the gem couldn't fetch correct email now.

Using these solutions:

- Use the latest authorization api paths as MSDN.
- Add 'wl.contacts_emails' scope to default.
- Use parse_email to parse contact's email.