### PR TITLE
modified gmail.rb importer to allow :scope args if provided.

### DIFF
--- a/lib/omnicontacts/importer/gmail.rb
+++ b/lib/omnicontacts/importer/gmail.rb
@@ -13,7 +13,7 @@ module OmniContacts
         @auth_host = "accounts.google.com"
         @authorize_path = "/o/oauth2/auth"
         @auth_token_path = "/o/oauth2/token"
-        @scope = "https://www.google.com/m8/feeds https://www.googleapis.com/auth/userinfo#email https://www.googleapis.com/auth/userinfo.profile"
+        @scope = (args[3] && args[3][:scope]) || "https://www.google.com/m8/feeds https://www.googleapis.com/auth/userinfo#email https://www.googleapis.com/auth/userinfo.profile"
         @contacts_host = "www.google.com"
         @contacts_path = "/m8/feeds/contacts/default/full"
         @max_results =  (args[3] && args[3][:max_results]) || 100

--- a/spec/omnicontacts/importer/gmail_spec.rb
+++ b/spec/omnicontacts/importer/gmail_spec.rb
@@ -5,6 +5,8 @@ describe OmniContacts::Importer::Gmail do
 
   let(:gmail) { OmniContacts::Importer::Gmail.new({}, "client_id", "client_secret") }
 
+  let(:gmail_with_scope_args) { OmniContacts::Importer::Gmail.new({}, "client_id", "client_secret", {scope: "https://www.google.com/m8/feeds https://www.googleapis.com/auth/userinfo#email https://www.googleapis.com/auth/contacts.readonly"}) }
+  
   let(:self_response) {
     '{
       "id":"16482944006464829443",
@@ -110,6 +112,7 @@ describe OmniContacts::Importer::Gmail do
 
     before(:each) do
       gmail.instance_variable_set(:@env, {})
+      gmail_with_scope_args.instance_variable_set(:@env, {})
     end
 
     it "should request the contacts by specifying version and code in the http headers" do
@@ -124,6 +127,9 @@ describe OmniContacts::Importer::Gmail do
         contacts_as_json
       end
       gmail.fetch_contacts_using_access_token token, token_type
+      
+      gmail.scope.should eq "https://www.google.com/m8/feeds https://www.googleapis.com/auth/userinfo#email https://www.googleapis.com/auth/userinfo.profile"
+      gmail_with_scope_args.scope.should eq "https://www.google.com/m8/feeds https://www.googleapis.com/auth/userinfo#email https://www.googleapis.com/auth/contacts.readonly"
     end
 
     it "should correctly parse id, name, email, gender, birthday, profile picture and relation for 1st contact" do


### PR DESCRIPTION
We wanted to make fewer requests for information when authenticating an app to Gmail. By allowing a client app to pass in different scope arguments this is now possible while retaining all the previous default functionality, i.e. if no scope args are passed, the original default scope is used. This was modeled on the preexisting :max_results argument in the initialize method. Specs were provided to validate this functionality.
