### PR TITLE
remove the old gmail image url hack

### DIFF
--- a/lib/omnicontacts/importer/gmail.rb
+++ b/lib/omnicontacts/importer/gmail.rb
@@ -151,13 +151,6 @@ module OmniContacts
           # Support older versions of the gem by keeping singular entries around
           contact[:phone_number] = contact[:phone_numbers][0][:number] if contact[:phone_numbers][0]
 
-          if entry['gContact$website'] && entry['gContact$website'][0]["rel"] == "profile"
-            contact[:id] = contact_id(entry['gContact$website'][0]["href"])
-            contact[:profile_picture] = image_url(contact[:id])
-          else
-            contact[:profile_picture] = image_url_from_email(contact[:email])
-          end
-
           if entry["link"] && entry["link"].is_a?(Array)
             entry["link"].each do |link|
               if link["type"] == 'image/*' && link["gd$etag"]
@@ -189,15 +182,11 @@ module OmniContacts
         contacts
       end
 
-      def image_url gmail_id
-        return "https://profiles.google.com/s2/photos/profile/" + gmail_id if gmail_id
-      end
-
       def current_user me, access_token, token_type
         return nil if me.nil?
         me = JSON.parse(me)
         user = {:id => me['id'], :email => me['email'], :name => me['name'], :first_name => me['given_name'],
-                :last_name => me['family_name'], :gender => me['gender'], :birthday => birthday(me['birthday']), :profile_picture => image_url(me['id']),
+                :last_name => me['family_name'], :gender => me['gender'], :birthday => birthday(me['birthday']), :profile_picture => me["picture"],
                 :access_token => access_token, :token_type => token_type
         }
         user

--- a/spec/omnicontacts/importer/gmail_spec.rb
+++ b/spec/omnicontacts/importer/gmail_spec.rb
@@ -165,7 +165,7 @@ describe OmniContacts::Importer::Gmail do
       result.last[:email].should eq("emilia.fox@gmail.com")
       result.last[:gender].should eq("female")
       result.last[:birthday].should eq({:day=>10, :month=>02, :year=>1974})
-      result.last[:profile_picture].should eq("https://profiles.google.com/s2/photos/profile/emilia.fox")
+      result.last[:profile_picture].should be_nil
       result.last[:relation].should eq('spouse')
       result.first[:address_1].should eq('1313 Trashview Court')
       result.first[:address_2].should eq('Apt. 13')
@@ -191,7 +191,7 @@ describe OmniContacts::Importer::Gmail do
       user[:email].should eq("chrisjohnson@gmail.com")
       user[:gender].should eq("male")
       user[:birthday].should eq({:day=>21, :month=>06, :year=>1982})
-      user[:profile_picture].should eq("https://profiles.google.com/s2/photos/profile/16482944006464829443")
+      user[:profile_picture].should eq("https://lh3.googleusercontent.com/-b8aFbTBM/AAAAAAI/IWA/vsek/photo.jpg")
     end
   end
 end


### PR DESCRIPTION
The old gmail url endpoint no longer exists. 
It throws a 404 on all those urls. 