### PR TITLE
Params from the initial request are passed through to callback

### DIFF
--- a/lib/omnicontacts/middleware/base_oauth.rb
+++ b/lib/omnicontacts/middleware/base_oauth.rb
@@ -34,8 +34,10 @@ module OmniContacts
       def call env
         @env = env
         if env["PATH_INFO"] =~ /^#{@listening_path}\/?$/
+          session['omnicontacts.params'] = Rack::Request.new(env).params
           handle_initial_request
         elsif env["PATH_INFO"] =~ /^#{redirect_path}/
+          env['omnicontacts.params'] = session.delete('omnicontacts.params')
           handle_callback
         else
           @app.call(env)
@@ -90,7 +92,8 @@ module OmniContacts
       def handle_error error_type, exception
         logger.puts("Error #{error_type} while processing #{@env["PATH_INFO"]}: #{exception.message}") if logger
         failure_url = "#{ MOUNT_PATH }failure?error_message=#{error_type}&importer=#{class_name}"
-        target_url = append_state_query(failure_url)
+        params_url = append_request_params(failure_url)
+        target_url = append_state_query(params_url)
         [302, {"Content-Type" => "text/html", "location" => target_url}, []]
       end
 
@@ -107,9 +110,17 @@ module OmniContacts
         "omnicontacts." + class_name
       end
 
+      def append_request_params(target_url)
+        return target_url unless @env['omnicontacts.params']
+        params = URI.encode_www_form(@env['omnicontacts.params'])
+        unless params.nil? or params.empty?
+          target_url = target_url + (target_url.include?("?")?"&":"?") + params
+        end
+        return target_url
+      end
+
       def append_state_query(target_url)
         state = Rack::Utils.parse_query(@env['QUERY_STRING'])['state']
-
         unless state.nil?
           target_url = target_url + (target_url.include?("?")?"&":"?") + 'state=' + state
         end

--- a/lib/omnicontacts/middleware/base_oauth.rb
+++ b/lib/omnicontacts/middleware/base_oauth.rb
@@ -112,7 +112,7 @@ module OmniContacts
 
       def append_request_params(target_url)
         return target_url unless @env['omnicontacts.params']
-        params = URI.encode_www_form(@env['omnicontacts.params'])
+        params = Rack::Utils.build_query(@env['omnicontacts.params'])
         unless params.nil? or params.empty?
           target_url = target_url + (target_url.include?("?")?"&":"?") + params
         end

--- a/spec/omnicontacts/middleware/base_oauth_spec.rb
+++ b/spec/omnicontacts/middleware/base_oauth_spec.rb
@@ -13,6 +13,14 @@ describe OmniContacts::Middleware::BaseOAuth do
       def redirect_path
         "#{ MOUNT_PATH }testprovider/callback"
       end
+
+      def self.mock_session
+        @mock_session ||= {}
+      end
+
+      def session
+        TestProvider.mock_session
+      end
     end
     OmniContacts.integration_test.enabled = true
   end
@@ -31,7 +39,7 @@ describe OmniContacts::Middleware::BaseOAuth do
     last_request.env["omnicontacts.contacts"].first[:email].should eq("user@example.com")
   end
 
-  it "should redurect to failure url" do
+  it "should redirect to failure url" do
     OmniContacts.integration_test.mock(:testprovider, "some_error" )
     get "#{ MOUNT_PATH }testprovider"
     get "#{MOUNT_PATH }testprovider/callback"
@@ -44,10 +52,31 @@ describe OmniContacts::Middleware::BaseOAuth do
     get "#{MOUNT_PATH }testprovider/callback?state=/parent/resource/id"
     last_response.headers["location"].should eq("#{ MOUNT_PATH }failure?error_message=internal_error&importer=testprovider&state=/parent/resource/id")
   end
+
+  it "should store request params in session" do
+    OmniContacts.integration_test.mock(:testprovider, :email => "user@example.com")
+    get "#{ MOUNT_PATH }testprovider?foo=bar"
+    app.session['omnicontacts.params'].should eq({'foo' => 'bar'})
+  end
+
+  it "should pass the params from session to callback environment " do
+    OmniContacts.integration_test.mock(:testprovider, :email => "user@example.com")
+    app.session.merge!({'omnicontacts.params' => {'foo' => 'bar'}})
+    get "#{MOUNT_PATH }testprovider/callback?state=/parent/resource/id"
+    last_request.env["omnicontacts.params"].should eq({'foo' => 'bar'})
+  end
+
+  it "should pass the params from session on failure" do
+    OmniContacts.integration_test.mock(:testprovider, "some_error" )
+    get "#{ MOUNT_PATH }testprovider"
+    app.session.merge!({'omnicontacts.params' => {'foo' => 'bar'}})
+    get "#{MOUNT_PATH }testprovider/callback"
+    last_response.should be_redirect
+    last_response.headers["location"].should be_include("foo=bar")
+  end
   
   after(:all) do 
     OmniContacts.integration_test.enabled = false
     OmniContacts.integration_test.clear_mocks
   end
-  
 end


### PR DESCRIPTION
On success:
The params from the request are stored in the environment env['omnicontacts.params']
On failure:
The params are in the failure URL.
Use case:
To persist useful context about the request made from different parts of the app.
