### PR TITLE
Outlook Importer

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ require "omnicontacts"
 
 Rails.application.middleware.use OmniContacts::Builder do
   importer :gmail, "client_id", "client_secret", {:redirect_path => "/oauth2callback", :ssl_ca_file => "/etc/ssl/certs/curl-ca-bundle.crt"}
-  importer :yahoo, "consumer_id", "consumer_secret", {:callback_path => '/callback'}
+  importer :yahoo, "consumer_id", "consumer_secret", {:callback_path => "/callback"}
   importer :linkedin, "consumer_id", "consumer_secret", {:redirect_path => "/oauth2callback", :state => '<long_unique_string_value>'}
   importer :hotmail, "client_id", "client_secret"
+  importer :outlook, "app_id", "app_secret"
   importer :facebook, "client_id", "client_secret"
 end
 
@@ -53,13 +54,16 @@ On the other hand it makes things much easier to leave the default value for `:r
 
 * For Hotmail : [Microsoft Developer Network](https://account.live.com/developers/applications/index)
 
+* For Outlook : [Microsoft Application Registration Portal](https://apps.dev.microsoft.com/)
+
 * For Facebook : [Facebook Developers](https://developers.facebook.com/apps)
 
 * For Linkedin : [Linkedin Developer Network](https://www.linkedin.com/secure/developer)
 
 
 ##### Note:
-Please go through [MSDN](http://msdn.microsoft.com/en-us/library/cc287659.aspx) if above Hotmail link will not work.
+Please go through [MSDN](http://msdn.microsoft.com/en-us/library/cc287659.aspx) if above Hotmail link will not work.  
+Outlook is a newer Microsoft API which allows to retrieve real email address instead of `email_hashes` when using Hotmail, it also works with all kinds of MS accounts (Office 365, Hotmail.com, Live.com, MSN.com, Outlook.com, and Passport.com).
 
 ## Integrating with your Application
 
@@ -172,7 +176,26 @@ The following table shows which fields are supported by which provider:
 		<td></td>
 	</tr>
 	<tr>
-	    <td>Linkedin</td>
+		<td>Outlook</td>
+		<td>X</td>
+		<td>X</td>
+		<td></td>
+		<td>X</td>
+		<td>X</td>
+		<td>X</td>
+		<td>X</td>
+		<td></td>
+		<td>X</td>
+		<td>X</td>
+		<td>X</td>
+		<td>X</td>
+		<td></td>
+		<td>X</td>
+		<td></td>
+		<td></td>
+	</tr>
+	<tr>
+	<td>Linkedin</td>
 		<td></td>
 		<td>X</td>
 		<td>X</td>
@@ -214,7 +237,7 @@ If the user does not authorize your application to access his/her contacts list,
 
 OmniContacts supports OAuth 1.0 and OAuth 2.0 token refresh, but for both it needs to persist data between requests. OmniContacts stores access tokens in the session. If you hit the 4KB cookie storage limit you better opt for the Memcache or the Active Record storage.
 
-Gmail requires you to register the redirect_path on their website along with your application. Make sure to use the same value present in the configuration file, or `/contacts/gmail/callback` if using the default. Also make sure that your full url is used including "www" if your site redirects from the root domain. 
+Gmail requires you to register the redirect_path on their website along with your application. Make sure to use the same value present in the configuration file, or `/contacts/gmail/callback` if using the default. Also make sure that your full url is used including "www" if your site redirects from the root domain.
 
 To configure the max number of contacts to download from Gmail, just add a max results parameter in your initializer:
 

--- a/lib/omnicontacts/importer.rb
+++ b/lib/omnicontacts/importer.rb
@@ -4,6 +4,7 @@ module OmniContacts
     autoload :Gmail, "omnicontacts/importer/gmail"
     autoload :Yahoo, "omnicontacts/importer/yahoo"
     autoload :Hotmail, "omnicontacts/importer/hotmail"
+    autoload :Outlook, "omnicontacts/importer/outlook"
     autoload :Facebook, "omnicontacts/importer/facebook"
     autoload :Linkedin, "omnicontacts/importer/linkedin"
 

--- a/lib/omnicontacts/importer/outlook.rb
+++ b/lib/omnicontacts/importer/outlook.rb
@@ -1,0 +1,115 @@
+require "omnicontacts/middleware/oauth2"
+require "omnicontacts/parse_utils"
+require "json"
+
+# Outlook contacts REST API
+# https://msdn.microsoft.com/en-us/office/office365/api/api-catalog#Outlookcontacts
+# https://msdn.microsoft.com/office/office365/api/contacts-rest-operations
+# Register app https://apps.dev.microsoft.com/
+module OmniContacts
+  module Importer
+    class Outlook < Middleware::OAuth2
+      include ParseUtils
+
+      attr_reader :auth_host, :authorize_path, :auth_token_path, :scope
+
+      def initialize app, client_id, client_secret, options ={}
+        super app, client_id, client_secret, options
+        @auth_host = "login.microsoftonline.com"
+        @authorize_path = "/common/oauth2/v2.0/authorize"
+        @scope = options[:permissions] || "openid profile https://outlook.office.com/contacts.read"
+        @auth_token_path = "/common/oauth2/v2.0/token"
+        @contacts_host = "outlook.office.com"
+        @contacts_path = "/api/v2.0/me/contacts"
+        @self_path = "/api/v2.0/me"
+      end
+
+      def fetch_contacts_using_access_token access_token, token_type
+        fetch_current_user(access_token, token_type)
+        contacts_response = https_get(@contacts_host, @contacts_path, {}, contacts_req_headers(access_token, token_type))
+        contacts_from_response contacts_response
+      end
+
+      def fetch_current_user access_token, token_type
+        self_response = https_get(@contacts_host, @self_path, {}, contacts_req_headers(access_token, token_type))
+        user = current_user self_response
+        set_current_user user
+      end
+
+      private
+
+      def contacts_req_headers token, token_type
+        {"Authorization" => "#{token_type} #{token}"}
+      end
+
+      def current_user me
+        return nil if me.nil?
+        me = JSON.parse(me)
+
+        name_splitted = me['DisplayName'].split(' ')
+        first_name = name_splitted.first
+        last_name = name_splitted.last if name_splitted.size > 1
+
+        user = empty_contact
+        user[:id]         = me['Id']
+        user[:email]      = me['EmailAddress']
+        user[:name]       = me['DisplayName']
+        user[:first_name] = normalize_name(first_name)
+        user[:last_name]  = normalize_name(last_name)
+        user
+      end
+
+      def contacts_from_response response_as_json
+        response = JSON.parse(response_as_json)
+        contacts = []
+        response['value'].each do |entry|
+          contact = empty_contact
+          # Full fields reference:
+          # https://msdn.microsoft.com/office/office365/api/complex-types-for-mail-contacts-calendar#RESTAPIResourcesContact
+          contact[:id]         = entry['Id']
+          contact[:first_name] = entry['GivenName']
+          contact[:last_name]  = entry['Surname']
+          contact[:name]       = entry['DisplayName']
+          contact[:email]      = parse_email(entry['EmailAddresses'])
+          contact[:birthday]   = birthday(entry['Birthday'])
+
+          address = [entry['HomeAddress'], entry['BusinessAddress'], entry['OtherAddress']].reject(&:empty?).first
+          if address
+            contact[:address_1] = address['Street']
+            contact[:city]      = address['City']
+            contact[:region]    = address['State']
+            contact[:postcode]  = address['PostalCode']
+            contact[:country]   = address['CountryOrRegion']
+          end
+
+          contacts << contact if contact[:name] || contact[:first_name]
+        end
+        contacts
+      end
+
+      def empty_contact
+        { :id => nil, :first_name => nil, :last_name => nil, :name => nil, :email => nil,
+          :gender => nil, :birthday => nil, :profile_picture => nil, :address_1 => nil,
+          :address_2 => nil, :city => nil, :region => nil, :postcode => nil, :relation => nil }
+      end
+
+      def parse_email emails
+        return nil if emails.nil?
+        emails.map! { |email| email['Address'] }
+        emails.select! { |email| valid_email? email }
+        emails.first
+      end
+
+      def birthday dob
+        return nil if dob.nil?
+        birthday = dob[0..9].split('-')
+        birthday[0] = nil if birthday[0].to_i < 1900 # if year is not set it returns 1604
+        return birthday_format(birthday[1], birthday[2], birthday[0])
+      end
+
+      def valid_email? value
+        /\A[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]+\z/.match(value)
+      end
+    end
+  end
+end

--- a/spec/omnicontacts/importer/outlook_spec.rb
+++ b/spec/omnicontacts/importer/outlook_spec.rb
@@ -1,0 +1,150 @@
+require "spec_helper"
+require "omnicontacts/importer/outlook"
+
+describe OmniContacts::Importer::Outlook do
+
+  let(:permissions) { "Contacts.Read" }
+  let(:outlook) { OmniContacts::Importer::Outlook.new({}, "app_id", "app_secret", {:permissions => permissions}) }
+
+  let(:self_response) {
+    '{
+      "@odata.context": "https://outlook.office.com/api/v2.0/$metadata#Me",
+      "@odata.id": "https://outlook.office.com/api/v2.0/Users(\'00034001-df52-d3d5-0000-000000000000@84df9e7f-e9f6-40af-b435-aaaaaaaaaaaa\')",
+      "Id": "00034001-df52-d3d5-0000-000000000000@84df9e7f-e9f6-40af-b435-aaaaaaaaaaaa",
+      "EmailAddress": "test.user@outlook.com",
+      "DisplayName": "Test User",
+      "Alias": "puid-00034001DF52D3D5",
+      "MailboxGuid": "00034001-df52-d3d5-0000-000000000000"
+    }'
+  }
+
+  let(:contacts_as_json) {
+    '{
+      "@odata.context": "https://outlook.office.com/api/v2.0/$metadata#Me/Contacts",
+      "value": [{
+        "@odata.id": "https://outlook.office.com/api/v2.0/Users(\'00034001-df52-d3d5-0000-000000000000@84df9e7f-e9f6-40af-b435-aaaaaaaaaaaa\')/Contacts(\'AQMkADAwATM0MDAAMS1kZjUyLWQzZDUtMDACLTAwCgBGAAADQ1hAWLJpwk6DZYyOhnclvgcAxCL3G7jnpkiRUVmiNrhjJgAAAgEOAAAAxCL3G7jnpkiRUVmiNrhjJgAAAixsAAAA\')",
+        "@odata.etag": "W/\"EQAAABYAAADEIvcbuOemSJFRWaI2uGMmAAAAlo4t\"",
+        "Id": "AQMkADAwATM0MDAAMS1kZjUyLWQzZDUtMDACLTAwCgBGAAADQ1hAWLJpwk6DZYyOhnclvgcAxCL3G7jnpkiRUVmiNrhjJgAAAgEOAAAAxCL3G7jnpkiRUVmiNrhjJgAAAixsAAAA",
+        "CreatedDateTime": "2016-04-13T21:25:24Z",
+        "LastModifiedDateTime": "2016-04-14T19:36:55Z",
+        "ChangeKey": "EQAAABYAAADEIvcbuOemSJFRWaI2uGMmAAAAlo4t",
+        "Categories": [],
+        "ParentFolderId": "AQMkADAwATM0MDAAMS1kZjUyLWQzZDUtMDACLTAwCgAuAAADQ1hAWLJpwk6DZYyOhnclvgEAxCL3G7jnpkiRUVmiNrhjJgAAAgEOAAAA",
+        "Birthday": "1604-08-14T00:00:00Z",
+        "FileAs": "Contact, First",
+        "DisplayName": "First Contact",
+        "GivenName": "First",
+        "Initials": null,
+        "MiddleName": null,
+        "NickName": null,
+        "Surname": "Contact",
+        "Title": null,
+        "YomiGivenName": null,
+        "YomiSurname": null,
+        "YomiCompanyName": null,
+        "Generation": null,
+        "EmailAddresses": [{
+          "Name": "contact.first@email.com",
+          "Address": "contact.first@email.com"
+        }, {
+          "Name": "contact.second@email.com",
+          "Address": "contact.second@email.com"
+        }],
+        "ImAddresses": [],
+        "JobTitle": null,
+        "CompanyName": null,
+        "Department": null,
+        "OfficeLocation": null,
+        "Profession": null,
+        "BusinessHomePage": null,
+        "AssistantName": null,
+        "Manager": null,
+        "HomePhones": [],
+        "MobilePhone1": null,
+        "BusinessPhones": [],
+        "HomeAddress": {
+          "Street": "address1",
+          "City": "city",
+          "State": "state",
+          "CountryOrRegion": "US",
+          "PostalCode": "89111"
+        },
+        "BusinessAddress": {},
+        "OtherAddress": {},
+        "SpouseName": null,
+        "PersonalNotes": null,
+        "Children": []
+      }]
+    }'
+  }
+
+  describe "fetch_contacts_using_access_token" do
+
+    let(:access_token) { "access_token" }
+    let(:token_type) { "token_type" }
+
+    before(:each) do
+      outlook.instance_variable_set(:@env, {"HTTP_HOST" => "http://example.com"})
+    end
+
+    it "should request the contacts by providing the authorization header with token_type and access_token" do
+      outlook.should_receive(:https_get) do |host, path, params, headers|
+        params.should eq({})
+        headers["Authorization"].should eq("token_type access_token")
+        self_response
+      end
+
+      outlook.should_receive(:https_get) do |host, path, params, headers|
+        params.should eq({})
+        headers["Authorization"].should eq("token_type access_token")
+        contacts_as_json
+      end
+      outlook.fetch_contacts_using_access_token access_token, token_type
+    end
+
+    it "should set requested permissions in the authorization url" do
+      outlook.authorization_url.should match(/scope=#{Regexp.quote(CGI.escape(permissions))}/)
+    end
+
+    it "should correctly parse id, name and email" do
+      outlook.should_receive(:https_get).and_return(self_response)
+      outlook.should_receive(:https_get).and_return(contacts_as_json)
+      result = outlook.fetch_contacts_using_access_token access_token, token_type
+
+      result.size.should be(1)
+      result.first[:id].should eq('AQMkADAwATM0MDAAMS1kZjUyLWQzZDUtMDACLTAwCgBGAAADQ1hAWLJpwk6DZYyOhnclvgcAxCL3G7jnpkiRUVmiNrhjJgAAAgEOAAAAxCL3G7jnpkiRUVmiNrhjJgAAAixsAAAA')
+      result.first[:first_name].should eq("First")
+      result.first[:last_name].should eq("Contact")
+      result.first[:name].should eq("First Contact")
+      result.first[:email].should eq("contact.first@email.com")
+      result.first[:birthday].should eq({ :day => 14, :month => 8, :year => nil })
+      result.first[:address_1].should eq("address1")
+      result.first[:address_2].should be_nil
+      result.first[:city].should eq("city")
+      result.first[:region].should eq("state")
+      result.first[:postcode].should eq("89111")
+      result.first[:country].should eq("US")
+      result.first[:gender].should be_nil
+      result.first[:profile_picture].should be_nil
+      result.first[:relation].should be_nil
+    end
+
+    it "should correctly parse and set logged in user information" do
+      outlook.should_receive(:https_get).and_return(self_response)
+      outlook.should_receive(:https_get).and_return(contacts_as_json)
+
+      outlook.fetch_contacts_using_access_token access_token, token_type
+
+      user = outlook.instance_variable_get(:@env)["omnicontacts.user"]
+      user.should_not be_nil
+      user[:id].should eq('00034001-df52-d3d5-0000-000000000000@84df9e7f-e9f6-40af-b435-aaaaaaaaaaaa')
+      user[:first_name].should eq("Test")
+      user[:last_name].should eq("User")
+      user[:name].should eq("Test User")
+      user[:email].should eq("test.user@outlook.com")
+      user[:gender].should be_nil
+      user[:birthday].should be_nil
+    end
+  end
+
+end


### PR DESCRIPTION
This is new importer which uses Outlook REST API v2.0 to retrieve contacts from any Microsoft account (Office 365, Hotmail.com, Live.com, MSN.com, Outlook.com, and Passport.com) it also provides _real_ email address instead of _email_hashes_ when using Hotmail. It also requires to create new credentials for the app on new [Microsoft Application Registration Portal](https://apps.dev.microsoft.com/).

I'm running this code for two weeks in production on a large site.