### PR TITLE
Rails 5 support

### DIFF
--- a/lib/omnicontacts/builder.rb
+++ b/lib/omnicontacts/builder.rb
@@ -3,7 +3,7 @@ require "omnicontacts"
 module OmniContacts
   class Builder < Rack::Builder
     def initialize(app, &block)
-      if rack14?
+      if rack14? || rack2?
         super
       else
         @app = app
@@ -15,6 +15,10 @@ module OmniContacts
       Rack.release.split('.')[1].to_i >= 4
     end
 
+    def rack2?
+      Rack.release.split('.')[0].to_i == 2
+    end
+
     def importer importer, *args
       middleware = OmniContacts::Importer.const_get(importer.to_s.capitalize)
       use middleware, *args
@@ -23,7 +27,7 @@ module OmniContacts
     end
 
     def call env
-      @ins << @app unless rack14? || @ins.include?(@app)
+      @ins << @app unless rack14? || rack2? || @ins.include?(@app)
       to_app.call(env)
     end
   end


### PR DESCRIPTION
Rails 5 now uses rack 2.x which was causing builder.rb’s initialize & call methods to behave as if it were a legacy rack version.

Added a check for rack 2.x and where appropriate.