### PR TITLE
Make rspec more modern

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,32 +1,38 @@
 PATH
   remote: .
   specs:
-    omnicontacts (0.3.9)
+    omnicontacts (0.3.10)
       json
       rack
 
 GEM
   remote: http://rubygems.org/
   specs:
-    diff-lcs (1.1.3)
-    json (1.8.3)
-    multi_json (1.1.0)
-    rack (1.4.1)
-    rack-test (0.6.1)
-      rack (>= 1.0)
-    rake (0.9.2.2)
-    rspec (2.8.0)
-      rspec-core (~> 2.8.0)
-      rspec-expectations (~> 2.8.0)
-      rspec-mocks (~> 2.8.0)
-    rspec-core (2.8.0)
-    rspec-expectations (2.8.0)
-      diff-lcs (~> 1.1.2)
-    rspec-mocks (2.8.0)
-    simplecov (0.6.1)
-      multi_json (~> 1.0)
-      simplecov-html (~> 0.5.3)
-    simplecov-html (0.5.3)
+    diff-lcs (1.3)
+    docile (1.3.2)
+    json (2.3.0)
+    rack (2.0.7)
+    rack-test (1.1.0)
+      rack (>= 1.0, < 3)
+    rake (13.0.1)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.0)
+      rspec-support (~> 3.9.0)
+    rspec-expectations (3.9.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.0)
+    simplecov (0.17.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
 
 PLATFORMS
   ruby
@@ -39,4 +45,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   1.10.6
+   2.1.0

--- a/spec/omnicontacts/authorization/oauth1_spec.rb
+++ b/spec/omnicontacts/authorization/oauth1_spec.rb
@@ -38,8 +38,9 @@ describe OmniContacts::Authorization::OAuth1 do
     end
 
     it "should raise an error if request is invalid" do
-      test_target.should_receive(:https_post).and_return("invalid_request")
-      expect { test_target.fetch_authorization_token }.to raise_error
+      allow(test_target).to receive(:https_post).and_return("invalid_request")
+
+      expect { test_target.fetch_authorization_token }.to(raise_error)
     end
 
   end

--- a/spec/omnicontacts/integration_test_spec.rb
+++ b/spec/omnicontacts/integration_test_spec.rb
@@ -5,21 +5,18 @@ describe IntegrationTest do
 
   context "mock_initial_request" do
     it "should redirect to the provider's redirect_path" do
-      provider = mock
       redirect_path = "/redirect_path"
-      provider.stub(:redirect_path => redirect_path)
+      provider = double('the-provider', redirect_path: redirect_path)
       IntegrationTest.instance.mock_authorization_from_user(provider)[1]["location"].should eq(redirect_path)
     end
   end
 
   context "mock_callback" do
-
-    before(:each) {
+    before do
       @env = {}
-      @provider = self.mock
-      @provider.stub(:class_name => "test")
+      @provider = double('the-mock', class_name: "test")
       IntegrationTest.instance.clear_mocks
-    }
+    end
 
     it "should return an empty contacts list" do
       IntegrationTest.instance.mock_fetch_contacts(@provider).should be_empty


### PR DESCRIPTION
This PR upgrades usages of `mock` to regular `expect` calls in RSpec.

It also upgrades the `Gemfile.lock` to have current versions.

This PR is a preparatory PR before running transpec on this repo, so that all RSpec can be fully upgraded to RSpec 3.

**Update:** unsuccessful at running transpec on this repository with this branch.